### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,25 +6,25 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-rfid KEYWORD1
+rfid	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-init KEYWORD2
-reset KEYWORD2
-writeMFRC522 KEYWORD2
-antennaOn KEYWORD2
-readMFRC522 KEYWORD2
-setBitMask KEYWORD2
-clearBitMask KEYWORD2
-calculateCRC KEYWORD2
-MFRC522ToCard KEYWORD2
-MFRC522Anticoll KEYWORD2
-MFRC522Auth KEYWORD2
-MFRC522Read KEYWORD2
-MFRC522Write KEYWORD2
-MFRC522Halt KEYWORD2
+init	KEYWORD2
+reset	KEYWORD2
+writeMFRC522	KEYWORD2
+antennaOn	KEYWORD2
+readMFRC522	KEYWORD2
+setBitMask	KEYWORD2
+clearBitMask	KEYWORD2
+calculateCRC	KEYWORD2
+MFRC522ToCard	KEYWORD2
+MFRC522Anticoll	KEYWORD2
+MFRC522Auth	KEYWORD2
+MFRC522Read	KEYWORD2
+MFRC522Write	KEYWORD2
+MFRC522Halt	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords